### PR TITLE
PAYLAPMEXT-189

### DIFF
--- a/src/main/java/com/payline/payment/oney/bean/request/OneyConfirmRequest.java
+++ b/src/main/java/com/payline/payment/oney/bean/request/OneyConfirmRequest.java
@@ -8,7 +8,6 @@ import com.payline.payment.oney.bean.common.payment.PaymentData;
 import com.payline.payment.oney.bean.response.OneyNotificationResponse;
 import com.payline.payment.oney.exception.InvalidDataException;
 import com.payline.payment.oney.service.impl.RequestConfigServiceImpl;
-import com.payline.payment.oney.utils.OneyConstants;
 import com.payline.payment.oney.utils.PluginUtils;
 import com.payline.payment.oney.utils.Required;
 import com.payline.pmapi.bean.capture.request.CaptureRequest;
@@ -129,7 +128,7 @@ public class OneyConfirmRequest extends ParameterizedUrlOneyRequest {
             this.encryptKey = RequestConfigServiceImpl.INSTANCE.getParameterValue(notificationRequest, PARTNER_CHIFFREMENT_KEY);
 
 
-            this.purchaseReference = OneyConstants.EXTERNAL_REFERENCE_TYPE + OneyConstants.PIPE + oneyResponse.getPurchase().getExternalReference();
+            this.purchaseReference = PluginUtils.fullPurchaseReference(oneyResponse.getPurchase().getExternalReference());
             this.pspGuid = RequestConfigServiceImpl.INSTANCE.getParameterValue(notificationRequest, PSP_GUID_KEY);
             this.callParameters = PluginUtils.getParametersMap(notificationRequest);
         }

--- a/src/main/java/com/payline/payment/oney/bean/request/OneyConfirmRequest.java
+++ b/src/main/java/com/payline/payment/oney/bean/request/OneyConfirmRequest.java
@@ -73,7 +73,7 @@ public class OneyConfirmRequest extends ParameterizedUrlOneyRequest {
 
         public Builder(RedirectionPaymentRequest paymentRequest) throws InvalidDataException {
             String merchantGuidValue = RequestConfigServiceImpl.INSTANCE.getParameterValue(paymentRequest, MERCHANT_GUID_KEY);
-            this.purchaseReference = paymentRequest.getRequestContext().getRequestData().get(EXTERNAL_REFERENCE_KEY);
+            this.purchaseReference = PluginUtils.fullPurchaseReference( paymentRequest.getOrder().getReference() );
             this.languageCode = paymentRequest.getRequestContext().getRequestData().get(LANGUAGE_CODE_KEY);
             this.merchantRequestId = generateMerchantRequestId(merchantGuidValue);
 

--- a/src/main/java/com/payline/payment/oney/bean/request/ParameterizedUrlOneyRequest.java
+++ b/src/main/java/com/payline/payment/oney/bean/request/ParameterizedUrlOneyRequest.java
@@ -1,6 +1,5 @@
 package com.payline.payment.oney.bean.request;
 
-import com.payline.payment.oney.utils.OneyConstants;
 import com.payline.payment.oney.utils.PluginUtils;
 import com.payline.pmapi.bean.payment.Order;
 

--- a/src/main/java/com/payline/payment/oney/bean/request/ParameterizedUrlOneyRequest.java
+++ b/src/main/java/com/payline/payment/oney/bean/request/ParameterizedUrlOneyRequest.java
@@ -1,6 +1,7 @@
 package com.payline.payment.oney.bean.request;
 
 import com.payline.payment.oney.utils.OneyConstants;
+import com.payline.payment.oney.utils.PluginUtils;
 import com.payline.pmapi.bean.payment.Order;
 
 public abstract class ParameterizedUrlOneyRequest extends OneyRequest {
@@ -16,7 +17,7 @@ public abstract class ParameterizedUrlOneyRequest extends OneyRequest {
 
         public Builder withPurchaseReferenceFromOrder( Order order ){
             if( order != null ){
-                this.purchaseReference = OneyConstants.EXTERNAL_REFERENCE_TYPE + OneyConstants.PIPE + order.getReference();
+                this.purchaseReference = PluginUtils.fullPurchaseReference( order.getReference() );
             }
             return this;
         }

--- a/src/main/java/com/payline/payment/oney/service/impl/CaptureServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/CaptureServiceImpl.java
@@ -11,17 +11,14 @@ import com.payline.pmapi.bean.capture.response.CaptureResponse;
 import com.payline.pmapi.bean.capture.response.impl.CaptureResponseFailure;
 import com.payline.pmapi.bean.capture.response.impl.CaptureResponseSuccess;
 import com.payline.pmapi.bean.common.FailureCause;
-import com.payline.pmapi.logger.LogManager;
 import com.payline.pmapi.service.CaptureService;
-import org.apache.logging.log4j.Logger;
 
 import static com.payline.payment.oney.bean.response.TransactionStatusResponse.createTransactionStatusResponseFromJson;
 import static com.payline.payment.oney.utils.OneyConstants.HTTP_OK;
 
 public class CaptureServiceImpl implements CaptureService {
-    private final String ERROR_STATUS = "TRANSACTION STATUS NOT FAVORABLE:";
+    private static final String ERROR_STATUS = "TRANSACTION STATUS NOT FAVORABLE:";
     private OneyHttpClient httpClient;
-    private static final Logger LOGGER = LogManager.getLogger(CaptureServiceImpl.class);
 
     public CaptureServiceImpl() {
         httpClient = OneyHttpClient.getInstance();

--- a/src/main/java/com/payline/payment/oney/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/PaymentServiceImpl.java
@@ -115,7 +115,7 @@ public class PaymentServiceImpl implements PaymentService {
                 //RequestData
                 oneyContext.put(OneyConstants.PSP_GUID_KEY, pspGuid);
                 oneyContext.put(OneyConstants.MERCHANT_GUID_KEY, merchGuid);
-                oneyContext.put(OneyConstants.EXTERNAL_REFERENCE_KEY, PluginUtils.fullPurchaseReference( purchase.getExternalReference()));
+                oneyContext.put(OneyConstants.EXTERNAL_REFERENCE_KEY, purchase.getExternalReference());
                 oneyContext.put(OneyConstants.PAYMENT_AMOUNT_KEY, paymentData.getAmount().toString());
                 oneyContext.put(OneyConstants.LANGUAGE_CODE_KEY, language);
 

--- a/src/main/java/com/payline/payment/oney/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/PaymentServiceImpl.java
@@ -115,7 +115,7 @@ public class PaymentServiceImpl implements PaymentService {
                 //RequestData
                 oneyContext.put(OneyConstants.PSP_GUID_KEY, pspGuid);
                 oneyContext.put(OneyConstants.MERCHANT_GUID_KEY, merchGuid);
-                oneyContext.put(OneyConstants.EXTERNAL_REFERENCE_KEY, OneyConstants.EXTERNAL_REFERENCE_TYPE + OneyConstants.PIPE + purchase.getExternalReference());
+                oneyContext.put(OneyConstants.EXTERNAL_REFERENCE_KEY, PluginUtils.fullPurchaseReference( purchase.getExternalReference()));
                 oneyContext.put(OneyConstants.PAYMENT_AMOUNT_KEY, paymentData.getAmount().toString());
                 oneyContext.put(OneyConstants.LANGUAGE_CODE_KEY, language);
 

--- a/src/main/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceImpl.java
@@ -6,6 +6,7 @@ import com.payline.payment.oney.bean.request.OneyTransactionStatusRequest;
 import com.payline.payment.oney.bean.response.OneyFailureResponse;
 import com.payline.payment.oney.bean.response.TransactionStatusResponse;
 import com.payline.payment.oney.exception.PluginTechnicalException;
+import com.payline.payment.oney.utils.OneyConstants;
 import com.payline.payment.oney.utils.OneyErrorHandler;
 import com.payline.payment.oney.utils.http.OneyHttpClient;
 import com.payline.payment.oney.utils.http.StringResponse;
@@ -25,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 
 import static com.payline.payment.oney.bean.response.PaymentErrorResponse.paymentErrorResponseFromJson;
 import static com.payline.payment.oney.bean.response.TransactionStatusResponse.createTransactionStatusResponseFromJson;
-import static com.payline.payment.oney.utils.OneyConstants.EXTERNAL_REFERENCE_KEY;
 import static com.payline.payment.oney.utils.OneyConstants.HTTP_OK;
 import static com.payline.payment.oney.utils.OneyErrorHandler.handleOneyFailureResponse;
 
@@ -42,7 +42,7 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
 
     @Override
     public PaymentResponse finalizeRedirectionPayment(RedirectionPaymentRequest redirectionPaymentRequest) {
-        String partnerTransactionId = redirectionPaymentRequest.getRequestContext().getRequestData().get(EXTERNAL_REFERENCE_KEY);
+        String partnerTransactionId = redirectionPaymentRequest.getRequestContext().getRequestData().get(OneyConstants.EXTERNAL_REFERENCE_KEY);
         boolean isSandbox = redirectionPaymentRequest.getEnvironment().isSandbox();
         try {
             OneyTransactionStatusRequest oneyTransactionStatusRequest = OneyTransactionStatusRequest.Builder.aOneyGetStatusRequest()
@@ -50,8 +50,7 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
                     .build();
             StringResponse status = this.httpClient.initiateGetTransactionStatus(oneyTransactionStatusRequest, isSandbox);
 
-
-            PaymentResponse paymentResponse = findErrorResponse(status, oneyTransactionStatusRequest.getPurchaseReference(), oneyTransactionStatusRequest.getEncryptKey());
+            PaymentResponse paymentResponse = findErrorResponse(status, partnerTransactionId, oneyTransactionStatusRequest.getEncryptKey());
             if (paymentResponse != null) {
                 return paymentResponse;
             } else {
@@ -63,17 +62,16 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
                     if (redirectionPaymentRequest.isCaptureNow() && "FAVORABLE".equals(response.getStatusPurchase().getStatusCode())) {
                         OneyConfirmRequest confirmRequest = new OneyConfirmRequest.Builder(redirectionPaymentRequest)
                                 .build();
-                        return this.validatePayment(confirmRequest, isSandbox);
+                        return this.validatePayment(confirmRequest, isSandbox, partnerTransactionId);
                     } else {
                         return handleTransactionStatusResponse(response, partnerTransactionId);
-
                     }
 
                 } else {
                     //Pas de statut pour cette demande
                     return OneyErrorHandler.getPaymentResponseFailure(
                             FailureCause.CANCEL,
-                            oneyTransactionStatusRequest.getPurchaseReference(),
+                            partnerTransactionId,
                             ERROR_CODE + "null");
                 }
             }
@@ -92,14 +90,14 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
 
     @Override
     public PaymentResponse handleSessionExpired(TransactionStatusRequest transactionStatusRequest) {
+        String externalReference = transactionStatusRequest.getOrder().getReference();
         try {
             OneyTransactionStatusRequest oneyTransactionStatusRequest = OneyTransactionStatusRequest.Builder.aOneyGetStatusRequest()
                     .fromTransactionStatusRequest(transactionStatusRequest)
                     .build();
             StringResponse status = this.httpClient.initiateGetTransactionStatus(oneyTransactionStatusRequest, transactionStatusRequest.getEnvironment().isSandbox());
 
-
-            PaymentResponse paymentResponse = findErrorResponse(status, oneyTransactionStatusRequest.getPurchaseReference(), oneyTransactionStatusRequest.getEncryptKey());
+            PaymentResponse paymentResponse = findErrorResponse(status, transactionStatusRequest.getOrder().getReference(), oneyTransactionStatusRequest.getEncryptKey());
             if (paymentResponse != null) {
                 return paymentResponse;
             } else {
@@ -110,16 +108,15 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
                     if ("FAVORABLE".equals(response.getStatusPurchase().getStatusCode())) {
                         OneyConfirmRequest confirmRequest = new OneyConfirmRequest.Builder(transactionStatusRequest)
                                 .build();
-                        return this.validatePayment(confirmRequest, transactionStatusRequest.getEnvironment().isSandbox());
+                        return this.validatePayment(confirmRequest, transactionStatusRequest.getEnvironment().isSandbox(), externalReference);
                     } else {
-                        return this.handleTransactionStatusResponse(response,
-                                oneyTransactionStatusRequest.getPurchaseReference());
+                        return this.handleTransactionStatusResponse(response, externalReference);
                     }
                 } else {
                     //Pas de statut pour cette demande
                     return OneyErrorHandler.getPaymentResponseFailure(
                             FailureCause.CANCEL,
-                            oneyTransactionStatusRequest.getPurchaseReference(),
+                            externalReference,
                             ERROR_CODE + "null");
                 }
             }
@@ -135,7 +132,7 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
      *
      * @return PaymentResponse
      */
-    public PaymentResponse validatePayment(OneyConfirmRequest confirmRequest, boolean isSandbox) throws PluginTechnicalException {
+    public PaymentResponse validatePayment(OneyConfirmRequest confirmRequest, boolean isSandbox, String partnerTransactionId) throws PluginTechnicalException {
         LOGGER.info("payment confirmation request nedeed");
         StringResponse oneyResponse = httpClient.initiateConfirmationPayment(confirmRequest, isSandbox);
 
@@ -145,15 +142,14 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
             LOGGER.error("Payment is null");
             return OneyErrorHandler.getPaymentResponseFailure(
                     FailureCause.PARTNER_UNKNOWN_ERROR,
-                    confirmRequest.getPurchaseReference(),
+                    partnerTransactionId,
                     "Empty partner response"
             );
 
         }
         try {
             //si erreur dans la requete http
-
-            PaymentResponse paymentResponse = findErrorResponse(oneyResponse, confirmRequest.getPurchaseReference(), confirmRequest.getEncryptKey());
+            PaymentResponse paymentResponse = findErrorResponse(oneyResponse, partnerTransactionId, confirmRequest.getEncryptKey());
             if (paymentResponse != null) {
                 return paymentResponse;
             } else {
@@ -163,10 +159,11 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
                     LOGGER.error("Transaction status response or purchase status is null");
                     return OneyErrorHandler.getPaymentResponseFailure(
                             FailureCause.REFUSED,
-                            confirmRequest.getPurchaseReference(),
+                            partnerTransactionId,
                             ERROR_CODE + "null");
                 }
-                return this.handleTransactionStatusResponse(responseDecrypted, confirmRequest.getPurchaseReference());
+
+                return this.handleTransactionStatusResponse(responseDecrypted, partnerTransactionId);
             }
         } catch (PluginTechnicalException e) {
             return e.toPaymentResponseFailure();

--- a/src/main/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceImpl.java
@@ -97,7 +97,7 @@ public class PaymentWithRedirectionServiceImpl implements PaymentWithRedirection
                     .build();
             StringResponse status = this.httpClient.initiateGetTransactionStatus(oneyTransactionStatusRequest, transactionStatusRequest.getEnvironment().isSandbox());
 
-            PaymentResponse paymentResponse = findErrorResponse(status, transactionStatusRequest.getOrder().getReference(), oneyTransactionStatusRequest.getEncryptKey());
+            PaymentResponse paymentResponse = findErrorResponse(status, externalReference, oneyTransactionStatusRequest.getEncryptKey());
             if (paymentResponse != null) {
                 return paymentResponse;
             } else {

--- a/src/main/java/com/payline/payment/oney/service/impl/RefundServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/RefundServiceImpl.java
@@ -54,7 +54,7 @@ public class RefundServiceImpl implements RefundService {
                 LOGGER.error("Refund is null");
                 return OneyErrorHandler.geRefundResponseFailure(
                         FailureCause.PARTNER_UNKNOWN_ERROR,
-                        oneyRefundRequest.getPurchaseReference(),
+                        refundRequest.getPartnerTransactionId(),
                         "Empty partner response");
             }
             //si erreur dans la requete http
@@ -76,7 +76,7 @@ public class RefundServiceImpl implements RefundService {
                     LOGGER.error("Refund is null");
                     return OneyErrorHandler.geRefundResponseFailure(
                             FailureCause.REFUSED,
-                            oneyRefundRequest.getPurchaseReference(),
+                            refundRequest.getPartnerTransactionId(),
                             "Purchase status : null");
                 }
 
@@ -89,10 +89,9 @@ public class RefundServiceImpl implements RefundService {
             }
         } catch (PluginTechnicalException e) {
             LOGGER.error("unable init the refund", e);
-            String ref = oneyRefundRequest != null ? oneyRefundRequest.getPurchaseReference() : "null";
             return OneyErrorHandler.geRefundResponseFailure(
                     e.getFailureCause(),
-                    ref,
+                    refundRequest.getPartnerTransactionId(),
                     e.getErrorCodeOrLabel());
         }catch (RuntimeException e) {
             LOGGER.error("Unexpected plugin error", e);

--- a/src/main/java/com/payline/payment/oney/service/impl/ResetServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/ResetServiceImpl.java
@@ -29,7 +29,6 @@ public class ResetServiceImpl implements ResetService {
 
     public ResetServiceImpl() {
         this.httpClient = OneyHttpClient.getInstance();
-        ;
     }
 
     @Override

--- a/src/main/java/com/payline/payment/oney/service/impl/ResetServiceImpl.java
+++ b/src/main/java/com/payline/payment/oney/service/impl/ResetServiceImpl.java
@@ -54,7 +54,7 @@ public class ResetServiceImpl implements ResetService {
 
 
                 return ResetResponseFailure.ResetResponseFailureBuilder.aResetResponseFailure()
-                        .withPartnerTransactionId(oneyRefundRequest.getPurchaseReference())
+                        .withPartnerTransactionId(resetRequest.getPartnerTransactionId())
                         .withFailureCause(FailureCause.PARTNER_UNKNOWN_ERROR)
                         .withErrorCode("Empty partner response")
                         .build();
@@ -77,7 +77,7 @@ public class ResetServiceImpl implements ResetService {
                     LOGGER.debug("oneyResponse StringResponse is null !");
                     LOGGER.error("Reset is null");
                     return ResetResponseFailure.ResetResponseFailureBuilder.aResetResponseFailure()
-                            .withPartnerTransactionId(oneyRefundRequest.getPurchaseReference())
+                            .withPartnerTransactionId(resetRequest.getPartnerTransactionId())
                             .withErrorCode("Purchase status : null")
                             .withFailureCause(FailureCause.REFUSED)
                             .build();
@@ -85,7 +85,7 @@ public class ResetServiceImpl implements ResetService {
 
                 LOGGER.info("Reset Success");
                 return ResetResponseSuccess.ResetResponseSuccessBuilder.aResetResponseSuccess()
-                        .withPartnerTransactionId(oneyRefundRequest.getPurchaseReference())
+                        .withPartnerTransactionId(resetRequest.getPartnerTransactionId())
                         .withStatusCode(responseDecrypted.getStatusPurchase().getStatusCode())
                         .build();
 

--- a/src/main/java/com/payline/payment/oney/utils/OneyConstants.java
+++ b/src/main/java/com/payline/payment/oney/utils/OneyConstants.java
@@ -73,9 +73,6 @@ public class OneyConstants {
     public static final String HEADER_COUNTRY_CODE = "oney.coutry.code";
 
 
-    public static final String PIPE = "%7C";
-
-
     // Request URL's
     public static final String PAYMENT_REQUEST_URL = "/payments/v1/purchase/facilypay_url";
     public static final String CONFIRM_REQUEST_URL = "/payments/v1/purchase";

--- a/src/main/java/com/payline/payment/oney/utils/PluginUtils.java
+++ b/src/main/java/com/payline/payment/oney/utils/PluginUtils.java
@@ -2,10 +2,8 @@ package com.payline.payment.oney.utils;
 
 
 import com.payline.payment.oney.exception.InvalidDataException;
-import com.payline.payment.oney.exception.InvalidFieldFormatException;
 import com.payline.payment.oney.exception.InvalidRequestException;
 import com.payline.payment.oney.service.impl.RequestConfigServiceImpl;
-import com.payline.payment.oney.service.impl.ResetServiceImpl;
 import com.payline.payment.oney.utils.properties.service.ConfigPropertiesEnum;
 import com.payline.pmapi.bean.capture.request.CaptureRequest;
 import com.payline.pmapi.bean.common.Buyer;
@@ -269,14 +267,6 @@ public class PluginUtils {
         return locale.getDisplayCountry();
     }
 
-    public static String parseReference(String reference) throws InvalidFieldFormatException {
-
-        if (reference == null || reference.isEmpty() || !reference.contains(OneyConstants.PIPE)) {
-            throw new InvalidFieldFormatException("Oney reference should contain a '|' : " + reference, "Oney.PurchaseReference");
-        }
-        return reference.split(OneyConstants.PIPE)[1];
-    }
-
     /**
      * check if a String respect ISO-3166 rules
      *
@@ -536,5 +526,20 @@ public class PluginUtils {
         // REFUSED / ABORTED / CANCELLED are not valid for refund or cancel ...
         LOGGER.error("Resquest's status {} is not valid for refund or cancel", transactionStatusRequest);
         return false;
+    }
+
+    /**
+     * Build the full external reference (with type and pipe separator).
+     * @param externalReference The external reference
+     * @return The full transaction reference
+     */
+    public static String fullPurchaseReference(String externalReference ){
+        if( externalReference == null ){
+            return null;
+        }
+        if( externalReference.startsWith( OneyConstants.EXTERNAL_REFERENCE_TYPE ) ){
+            return externalReference;
+        }
+        return OneyConstants.EXTERNAL_REFERENCE_TYPE + "|" + externalReference;
     }
 }

--- a/src/main/java/com/payline/payment/oney/utils/http/OneyHttpClient.java
+++ b/src/main/java/com/payline/payment/oney/utils/http/OneyHttpClient.java
@@ -9,6 +9,7 @@ import org.apache.http.Header;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -160,7 +161,12 @@ public class OneyHttpClient extends AbstractHttpClient {
         Map<String, String> parameters = new HashMap<>(request.getCallParameters());
         parameters.put(PSP_GUID, request.getPspGuid());
         parameters.put(MERCHANT_GUID, request.getMerchantGuid());
-        parameters.put(REFERENCE, URLEncoder.encode(request.getPurchaseReference()));
+        try {
+            parameters.put(REFERENCE, URLEncoder.encode(request.getPurchaseReference(), StandardCharsets.UTF_8.name()));
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new PluginTechnicalException(e, "Plugin error: while encoding purchaseReference");
+        }
         String path = buildConfirmOrderPath(CONFIRM_REQUEST_URL, parameters);
         String jsonBody = null;
         if (Boolean.valueOf(ConfigPropertiesEnum.INSTANCE.get(CHIFFREMENT_IS_ACTIVE))) {
@@ -179,7 +185,12 @@ public class OneyHttpClient extends AbstractHttpClient {
         Map<String, String> parameters = new HashMap<>(request.getCallParameters());
         parameters.put(PSP_GUID, request.getPspGuid());
         parameters.put(MERCHANT_GUID, request.getMerchantGuid());
-        parameters.put(REFERENCE, URLEncoder.encode(request.getPurchaseReference()));
+        try {
+            parameters.put(REFERENCE, URLEncoder.encode(request.getPurchaseReference(), StandardCharsets.UTF_8.name()));
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new PluginTechnicalException(e, "Plugin error: while encoding purchaseReference");
+        }
         String path = buildRefundOrderPath(CANCEL_REQUEST_URL, parameters);
         String jsonBody;
         if (Boolean.valueOf(ConfigPropertiesEnum.INSTANCE.get(CHIFFREMENT_IS_ACTIVE))) {
@@ -193,11 +204,16 @@ public class OneyHttpClient extends AbstractHttpClient {
     }
 
     public StringResponse initiateGetTransactionStatus(OneyTransactionStatusRequest request, boolean isSandbox)
-            throws HttpCallException {
+            throws PluginTechnicalException {
         Map<String, String> parameters = new HashMap<>(request.getCallParameters());
         parameters.put(PSP_GUID, request.getPspGuid());
         parameters.put(MERCHANT_GUID, request.getMerchantGuid());
-        parameters.put(REFERENCE, URLEncoder.encode(request.getPurchaseReference()));
+        try {
+            parameters.put(REFERENCE, URLEncoder.encode(request.getPurchaseReference(), StandardCharsets.UTF_8.name()));
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new PluginTechnicalException(e, "Plugin error: while encoding purchaseReference");
+        }
 
         Map<String, String> urlParameters = new HashMap<>();
         urlParameters.put(LANGUAGE_CODE, request.getLanguageCode());

--- a/src/main/java/com/payline/payment/oney/utils/http/OneyHttpClient.java
+++ b/src/main/java/com/payline/payment/oney/utils/http/OneyHttpClient.java
@@ -9,6 +9,7 @@ import org.apache.http.Header;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -159,7 +160,7 @@ public class OneyHttpClient extends AbstractHttpClient {
         Map<String, String> parameters = new HashMap<>(request.getCallParameters());
         parameters.put(PSP_GUID, request.getPspGuid());
         parameters.put(MERCHANT_GUID, request.getMerchantGuid());
-        parameters.put(REFERENCE, request.getPurchaseReference());
+        parameters.put(REFERENCE, URLEncoder.encode(request.getPurchaseReference()));
         String path = buildConfirmOrderPath(CONFIRM_REQUEST_URL, parameters);
         String jsonBody = null;
         if (Boolean.valueOf(ConfigPropertiesEnum.INSTANCE.get(CHIFFREMENT_IS_ACTIVE))) {
@@ -178,7 +179,7 @@ public class OneyHttpClient extends AbstractHttpClient {
         Map<String, String> parameters = new HashMap<>(request.getCallParameters());
         parameters.put(PSP_GUID, request.getPspGuid());
         parameters.put(MERCHANT_GUID, request.getMerchantGuid());
-        parameters.put(REFERENCE, request.getPurchaseReference());
+        parameters.put(REFERENCE, URLEncoder.encode(request.getPurchaseReference()));
         String path = buildRefundOrderPath(CANCEL_REQUEST_URL, parameters);
         String jsonBody;
         if (Boolean.valueOf(ConfigPropertiesEnum.INSTANCE.get(CHIFFREMENT_IS_ACTIVE))) {
@@ -196,7 +197,7 @@ public class OneyHttpClient extends AbstractHttpClient {
         Map<String, String> parameters = new HashMap<>(request.getCallParameters());
         parameters.put(PSP_GUID, request.getPspGuid());
         parameters.put(MERCHANT_GUID, request.getMerchantGuid());
-        parameters.put(REFERENCE, request.getPurchaseReference());
+        parameters.put(REFERENCE, URLEncoder.encode(request.getPurchaseReference()));
 
         Map<String, String> urlParameters = new HashMap<>();
         urlParameters.put(LANGUAGE_CODE, request.getLanguageCode());

--- a/src/test/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/PaymentWithRedirectionServiceTest.java
@@ -46,10 +46,11 @@ public class PaymentWithRedirectionServiceTest extends OneyConfigBean {
         StringResponse responseMocked = createStringResponse(200, "OK", "{\"encrypted_message\":\"+l2i0o7hGRh+wJO02++ulzsMg0QfZ1N009CwI1PLZzBnbfv6/Enufe5TriN1gKQkEmbMYU0PMtHdk+eF7boW/lsIc5PmjpFX1E/4MUJGkzI=\"}");
         Mockito.doReturn(responseMocked).when(httpClient).doPost(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap());
 
-        OneyConfirmRequest paymentRequest = new OneyConfirmRequest.Builder(createCompleteRedirectionPaymentBuilder())
+        RedirectionPaymentRequest redirectionPaymentRequest = createCompleteRedirectionPaymentBuilder();
+        OneyConfirmRequest paymentRequest = new OneyConfirmRequest.Builder(redirectionPaymentRequest)
                 .build();
 
-        PaymentResponse response = service.validatePayment(paymentRequest, true);
+        PaymentResponse response = service.validatePayment(paymentRequest, true, redirectionPaymentRequest.getOrder().getReference());
 
         if (response.getClass() == PaymentResponseSuccess.class) {
             PaymentResponseSuccess success = (PaymentResponseSuccess) response;
@@ -65,10 +66,11 @@ public class PaymentWithRedirectionServiceTest extends OneyConfigBean {
         StringResponse responseMocked = createStringResponse(400, "Bad Request", "{\"Payments_Error_Response\":{\"error_list \":[{\"field\":\"Merchant_request_id\",\"error_code\":\"ERR_04\",\"error_label\":\"Value of the field is invalid [{String}]\"}]}}");
         Mockito.doReturn(responseMocked).when(httpClient).doPost(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap());
 
-        OneyConfirmRequest paymentRequest = new OneyConfirmRequest.Builder(createCompleteRedirectionPaymentBuilder())
+        RedirectionPaymentRequest redirectionPaymentRequest = createCompleteRedirectionPaymentBuilder();
+        OneyConfirmRequest paymentRequest = new OneyConfirmRequest.Builder(redirectionPaymentRequest)
                 .build();
 
-        PaymentResponse response = service.validatePayment(paymentRequest, true);
+        PaymentResponse response = service.validatePayment(paymentRequest, true, redirectionPaymentRequest.getOrder().getReference());
         PaymentResponseFailure fail = (PaymentResponseFailure) response;
         Assertions.assertEquals("400 - ERR_04 - Merchant_request_id", fail.getErrorCode());
         Assertions.assertEquals(FailureCause.INVALID_DATA, fail.getFailureCause());
@@ -80,14 +82,13 @@ public class PaymentWithRedirectionServiceTest extends OneyConfigBean {
         StringResponse responseMocked = createStringResponse(404, "Not Found", "{\"statusCode\": 404, \"message\": \"Resource not found\"}");
         Mockito.doReturn(responseMocked).when(httpClient).doPost(Mockito.anyString(), Mockito.anyString(), Mockito.anyMap());
 
-        OneyConfirmRequest paymentRequest = new OneyConfirmRequest.Builder(createCompleteRedirectionPaymentBuilder())
+        RedirectionPaymentRequest redirectionPaymentRequest = createCompleteRedirectionPaymentBuilder();
+        OneyConfirmRequest paymentRequest = new OneyConfirmRequest.Builder(redirectionPaymentRequest)
                 .build();
 
-        PaymentResponseFailure response = (PaymentResponseFailure) service.validatePayment(paymentRequest, true);
+        PaymentResponseFailure response = (PaymentResponseFailure) service.validatePayment(paymentRequest, true, redirectionPaymentRequest.getOrder().getReference());
         Assertions.assertEquals("404", response.getErrorCode());
         Assertions.assertEquals(FailureCause.COMMUNICATION_ERROR, response.getFailureCause());
-
-
     }
 
     @Test
@@ -96,9 +97,12 @@ public class PaymentWithRedirectionServiceTest extends OneyConfigBean {
         StringResponse responseMocked = createStringResponse(404, "Bad request", "[]");
         Mockito.doReturn(responseMocked).when(httpClient).initiateConfirmationPayment( Mockito.any(OneyConfirmRequest.class), anyBoolean() );
 
+        RedirectionPaymentRequest redirectionPaymentRequest = createCompleteRedirectionPaymentBuilder();
+        OneyConfirmRequest paymentRequest = new OneyConfirmRequest.Builder(redirectionPaymentRequest)
+                .build();
+
         // when calling the method validatePayment
-        PaymentResponse response = service.validatePayment( new OneyConfirmRequest.Builder(createCompleteRedirectionPaymentBuilder())
-                .build(), true );
+        PaymentResponse response = service.validatePayment( paymentRequest, true, redirectionPaymentRequest.getOrder().getReference());
 
         // then a PaymentResponseFailure with the FailureCause.COMMUNICATION_ERROR is returned
         Assertions.assertTrue( response instanceof PaymentResponseFailure );
@@ -111,9 +115,12 @@ public class PaymentWithRedirectionServiceTest extends OneyConfigBean {
         StringResponse responseMocked = createStringResponse(200, "OK", "[]");
         Mockito.doReturn(responseMocked).when(httpClient).initiateConfirmationPayment( Mockito.any(OneyConfirmRequest.class), anyBoolean() );
 
+        RedirectionPaymentRequest redirectionPaymentRequest = createCompleteRedirectionPaymentBuilder();
+        OneyConfirmRequest paymentRequest = new OneyConfirmRequest.Builder(redirectionPaymentRequest)
+                .build();
+
         // when calling the method validatePayment
-        PaymentResponse response = service.validatePayment( new OneyConfirmRequest.Builder(createCompleteRedirectionPaymentBuilder())
-                .build(), true );
+        PaymentResponse response = service.validatePayment( paymentRequest, true, redirectionPaymentRequest.getOrder().getReference());
 
         // then a PaymentResponseFailure with the FailureCause.COMMUNICATION_ERROR is returned
         Assertions.assertTrue( response instanceof PaymentResponseFailure );

--- a/src/test/java/com/payline/payment/oney/service/impl/RefundServiceImplTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/RefundServiceImplTest.java
@@ -75,7 +75,7 @@ public class RefundServiceImplTest extends OneyConfigBean {
         Assertions.assertSame(response.getClass(), RefundResponseFailure.class);
         RefundResponseFailure fail = (RefundResponseFailure) response;
         Assertions.assertEquals(FailureCause.REFUSED, fail.getFailureCause());
-        Assertions.assertEquals(PluginUtils.fullPurchaseReference(refundReq.getOrder().getReference()), fail.getPartnerTransactionId());
+        Assertions.assertEquals(refundReq.getOrder().getReference(), fail.getPartnerTransactionId());
     }
 
     @Test

--- a/src/test/java/com/payline/payment/oney/service/impl/RefundServiceImplTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/RefundServiceImplTest.java
@@ -5,6 +5,7 @@ import com.payline.payment.oney.bean.request.OneyTransactionStatusRequest;
 import com.payline.payment.oney.exception.PluginTechnicalException;
 import com.payline.payment.oney.utils.OneyConfigBean;
 import com.payline.payment.oney.utils.OneyConstants;
+import com.payline.payment.oney.utils.PluginUtils;
 import com.payline.payment.oney.utils.http.OneyHttpClient;
 import com.payline.payment.oney.utils.http.StringResponse;
 import com.payline.pmapi.bean.common.FailureCause;
@@ -74,7 +75,7 @@ public class RefundServiceImplTest extends OneyConfigBean {
         Assertions.assertSame(response.getClass(), RefundResponseFailure.class);
         RefundResponseFailure fail = (RefundResponseFailure) response;
         Assertions.assertEquals(FailureCause.REFUSED, fail.getFailureCause());
-        Assertions.assertEquals(OneyConstants.EXTERNAL_REFERENCE_TYPE + OneyConstants.PIPE + refundReq.getOrder().getReference(), fail.getPartnerTransactionId());
+        Assertions.assertEquals(PluginUtils.fullPurchaseReference(refundReq.getOrder().getReference()), fail.getPartnerTransactionId());
     }
 
     @Test

--- a/src/test/java/com/payline/payment/oney/service/impl/ResetServiceImplTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/ResetServiceImplTest.java
@@ -68,6 +68,6 @@ public class ResetServiceImplTest {
         Assertions.assertSame(response.getClass(), ResetResponseFailure.class);
         ResetResponseFailure fail = (ResetResponseFailure) response;
         Assertions.assertEquals(FailureCause.REFUSED, fail.getFailureCause());
-        Assertions.assertEquals(PluginUtils.fullPurchaseReference(resetReq.getOrder().getReference()), fail.getPartnerTransactionId());
+        Assertions.assertEquals(resetReq.getOrder().getReference(), fail.getPartnerTransactionId());
     }
 }

--- a/src/test/java/com/payline/payment/oney/service/impl/ResetServiceImplTest.java
+++ b/src/test/java/com/payline/payment/oney/service/impl/ResetServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.payline.payment.oney.service.impl;
 
 import com.payline.payment.oney.utils.OneyConstants;
+import com.payline.payment.oney.utils.PluginUtils;
 import com.payline.payment.oney.utils.http.OneyHttpClient;
 import com.payline.payment.oney.utils.http.StringResponse;
 import com.payline.pmapi.bean.common.FailureCause;
@@ -67,6 +68,6 @@ public class ResetServiceImplTest {
         Assertions.assertSame(response.getClass(), ResetResponseFailure.class);
         ResetResponseFailure fail = (ResetResponseFailure) response;
         Assertions.assertEquals(FailureCause.REFUSED, fail.getFailureCause());
-        Assertions.assertEquals(OneyConstants.EXTERNAL_REFERENCE_TYPE + OneyConstants.PIPE + resetReq.getOrder().getReference(), fail.getPartnerTransactionId());
+        Assertions.assertEquals(PluginUtils.fullPurchaseReference(resetReq.getOrder().getReference()), fail.getPartnerTransactionId());
     }
 }

--- a/src/test/java/com/payline/payment/oney/utils/PluginUtilsTest.java
+++ b/src/test/java/com/payline/payment/oney/utils/PluginUtilsTest.java
@@ -396,47 +396,6 @@ public class PluginUtilsTest {
     }
 
     @Test
-    public void parseReference_noPipe() {
-        Throwable exception = Assertions.assertThrows(InvalidFieldFormatException.class, () -> {
-
-
-            parseReference("test#test");
-
-        });
-
-    }
-
-
-    @Test
-    public void parseReference_emptyReference() {
-        Throwable exception = Assertions.assertThrows(InvalidFieldFormatException.class, () -> {
-
-
-            parseReference("");
-
-        });
-
-    }
-
-
-    @Test
-    public void parseReference_nullReference() {
-        Throwable exception = Assertions.assertThrows(InvalidFieldFormatException.class, () -> {
-
-
-            parseReference(null);
-
-        });
-
-    }
-
-    @Test
-    public void testParseReference() throws InvalidFieldFormatException {
-        String ref = parseReference("xxx%7Ctest");
-        Assertions.assertEquals("test", ref);
-    }
-
-    @Test
     public void testGenerateMerchantRequestId() throws Exception {
 
         merchantId1 = generateMerchantRequestId("merchantId");

--- a/src/test/java/com/payline/payment/oney/utils/TestUtils.java
+++ b/src/test/java/com/payline/payment/oney/utils/TestUtils.java
@@ -45,7 +45,7 @@ public class TestUtils {
     public static final String CONFIRM_AMOUNT = "40800";
     private static final String TRANSACTION_ID = "455454545415451198120";
     private static final String EXTERNAL_REFERENCE = "123456789A";
-    private static final String CONFIRM_EXTERNAL_REFERENCE = OneyConstants.EXTERNAL_REFERENCE_TYPE + PIPE + EXTERNAL_REFERENCE;
+    private static final String CONFIRM_EXTERNAL_REFERENCE = PluginUtils.fullPurchaseReference( EXTERNAL_REFERENCE );
 
     private static final Currency CURRENCY_EUR = Currency.getInstance("EUR");
     private static final Locale LOCALE_FR = Locale.FRANCE;

--- a/src/test/java/com/payline/payment/oney/utils/TestUtils.java
+++ b/src/test/java/com/payline/payment/oney/utils/TestUtils.java
@@ -197,7 +197,7 @@ public class TestUtils {
         Map<String, String> requestData = new HashMap<>();
         requestData.put(TEST_PSP_GUID_KEY, GUID_KEY);
         requestData.put(SECRET_KEY, TestUtils.getSecretKey());
-        requestData.put(EXTERNAL_REFERENCE_KEY, CONFIRM_EXTERNAL_REFERENCE);
+        requestData.put(EXTERNAL_REFERENCE_KEY, EXTERNAL_REFERENCE);
         requestData.put(LANGUAGE_CODE_KEY, CONFIRM_EXTERNAL_REFERENCE);
 
 
@@ -467,7 +467,7 @@ public class TestUtils {
                 .withSoftDescriptor(SOFT_DESCRIPTOR)
                 .withEnvironment(TEST_ENVIRONMENT)
                 .withPartnerConfiguration(createDefaultPartnerConfiguration())
-                .withPartnerTransactionId(CONFIRM_EXTERNAL_REFERENCE)
+                .withPartnerTransactionId(TRANSACTION_ID)
                 .withTransactionId(createTransactionId())
                 .build();
     }
@@ -486,7 +486,7 @@ public class TestUtils {
                 .withSoftDescriptor(SOFT_DESCRIPTOR)
                 .withEnvironment(TEST_ENVIRONMENT)
                 .withPartnerConfiguration(createDefaultPartnerConfiguration())
-                .withPartnerTransactionId(CONFIRM_EXTERNAL_REFERENCE)
+                .withPartnerTransactionId(TRANSACTION_ID)
                 .withTransactionId(createTransactionId())
                 .build();
     }

--- a/src/test/java/com/payline/payment/oney/utils/http/OneyHttpClientTest.java
+++ b/src/test/java/com/payline/payment/oney/utils/http/OneyHttpClientTest.java
@@ -4,6 +4,7 @@ import com.payline.payment.oney.bean.common.PurchaseCancel;
 import com.payline.payment.oney.bean.request.OneyRefundRequest;
 import com.payline.payment.oney.bean.request.OneyTransactionStatusRequest;
 import com.payline.payment.oney.utils.OneyConstants;
+import com.payline.payment.oney.utils.PluginUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -17,6 +18,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.reflect.Whitebox;
 
+import java.net.URLEncoder;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,7 +55,7 @@ public class OneyHttpClientTest {
         params = new HashMap<>();
         params.put("psp_guid", "6ba2a5e2-df17-4ad7-8406-6a9fc488a60a");
         params.put("merchant_guid", "9813e3ff-c365-43f2-8dca-94b850befbf9");
-        params.put("reference", OneyConstants.EXTERNAL_REFERENCE_TYPE + OneyConstants.PIPE + "455454545415451198a");
+        params.put("reference", URLEncoder.encode(PluginUtils.fullPurchaseReference("455454545415451198a")));
         params.put(PARTNER_API_URL, "https://oney-staging.azure-api.net");
 
         urlParams = new HashMap<>();
@@ -139,7 +141,7 @@ public class OneyHttpClientTest {
                 .withLanguageCode("FR")
                 .withMerchantGuid("9813e3ff-c365-43f2-8dca-94b850befbf9")
                 .withPspGuid("6ba2a5e2-df17-4ad7-8406-6a9fc488a60a")
-                .withPurchaseReference(OneyConstants.EXTERNAL_REFERENCE_TYPE + OneyConstants.PIPE + "455454545415451198114")
+                .withPurchaseReference(PluginUtils.fullPurchaseReference("455454545415451198114"))
                 .withEncryptKey("66s581CG5W+RLEqZHAGQx+vskjy660Kt8x8rhtRpXtY=")
                 .withCallParameters(params)
                 .build();
@@ -165,7 +167,7 @@ public class OneyHttpClientTest {
                 .withMerchantGuid("9813e3ff-c365-43f2-8dca-94b850befbf9")
                 .withMerchantRequestId(merchantReqId)
                 .withPspGuid("6ba2a5e2-df17-4ad7-8406-6a9fc488a60a")
-                .withPurchaseReference(OneyConstants.EXTERNAL_REFERENCE_TYPE + OneyConstants.PIPE + "455454545415451198119")
+                .withPurchaseReference(PluginUtils.fullPurchaseReference("455454545415451198119"))
                 .withEncryptKey("66s581CG5W+RLEqZHAGQx+vskjy660Kt8x8rhtRpXtY=")
                 .withPurchase(PurchaseCancel.Builder.aPurchaseCancelBuilder()
                         .withReasonCode(1)


### PR DESCRIPTION
PAYLAPMEXT-189 : Suppression de l'external_reference_type (CMDE) et du séparateur (|) de tous les `partnerTransactionId` renvoyés à Payline. 